### PR TITLE
Add Moto Cards block

### DIFF
--- a/blocks/motocards/_motocards.json
+++ b/blocks/motocards/_motocards.json
@@ -1,0 +1,68 @@
+{
+  "definitions": [
+    {
+      "title": "Moto Cards",
+      "id": "motocards",
+      "plugins": {
+        "xwalk": {
+          "page": {
+            "resourceType": "core/franklin/components/block/v1/block",
+            "template": {
+              "name": "Moto Cards",
+              "filter": "motocards"
+            }
+          }
+        }
+      }
+    },
+    {
+      "title": "Card",
+      "id": "card",
+      "plugins": {
+        "xwalk": {
+          "page": {
+            "resourceType": "core/franklin/components/block/v1/block/item",
+            "template": {
+              "name": "Card",
+              "model": "card"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "models": [
+    {
+      "id": "card",
+      "fields": [
+        {
+          "component": "reference",
+          "valueType": "string",
+          "name": "image",
+          "label": "Image",
+          "multi": false
+        },
+        {
+          "component": "richtext",
+          "name": "text",
+          "value": "",
+          "label": "Text",
+          "valueType": "string"
+        },
+        {
+          "component": "aem-content",
+          "name": "cardLink",
+          "label": "Card Link"
+        }
+      ]
+    }
+  ],
+  "filters": [
+    {
+      "id": "motocards",
+      "components": [
+        "card"
+      ]
+    }
+  ]
+}

--- a/blocks/motocards/motocards.css
+++ b/blocks/motocards/motocards.css
@@ -1,0 +1,72 @@
+
+main > .section > div.motocards-wrapper {
+  max-width: unset;
+  padding: 0;
+   media (width >= 900px) {
+      max-width: unset;
+      padding: 0;
+   }
+}
+.motocards > ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(316px, 1fr));
+}
+
+.motocards > ul > li {
+  background: transparent;
+  border-radius: 0;
+  overflow: hidden;
+  position: relative;
+}
+
+.motocards .motocards-link {
+  display: block;
+  color: inherit;
+  text-decoration: none;
+  height: 100%;
+  position: relative;
+}
+
+.motocards .motocards-card-image {
+  position: relative;
+  line-height: 0;
+}
+
+.motocards .motocards-card-image img {
+  width: 100%;
+  height: auto;
+  object-fit: fill;
+  display: block;
+}
+.motocards .motocards-card-image:hover img {
+ transform: scale(1.1);
+ transition: all ease 1s;
+}
+
+/* Title overlay on image */
+.motocards .motocards-card-body {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background: linear-gradient(to bottom,transparent 0, rgba(0,0,0,0.50) 100%);
+  color: #fff;
+  padding: 16px;
+  font-family: "guardiansans-semibold";
+  z-index: 1;
+}
+
+.motocards .motocards-card-body p {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+@media (max-width: 768px) {
+  .motocards > ul {
+    grid-template-columns: 1fr;
+  }
+}

--- a/blocks/motocards/motocards.js
+++ b/blocks/motocards/motocards.js
@@ -1,0 +1,39 @@
+import { createOptimizedPicture } from '../../scripts/aem.js';
+import { moveInstrumentation } from '../../scripts/scripts.js';
+
+export default function decorate(block) {
+  /* change to ul, li */
+  const ul = document.createElement('ul');
+  [...block.children].forEach((row) => {
+    const li = document.createElement('li');
+    moveInstrumentation(row, li);
+    while (row.firstElementChild) li.append(row.firstElementChild);
+    [...li.children].forEach((div) => {
+      if (div.children.length === 1 && div.querySelector('picture')) div.className = 'motocards-card-image';
+      else div.className = 'motocards-card-body';
+    });
+    const link = li.querySelector('a');
+    if (link) {
+      const url = link.getAttribute('href');
+      const wrapper = document.createElement('a');
+      wrapper.href = url;
+      wrapper.className = 'motocards-link';
+      moveInstrumentation(li, wrapper);
+
+      // Remove old links inside
+      li.querySelectorAll('a').forEach((a) => a.remove());
+
+      // Move all li children into wrapper
+      while (li.firstChild) wrapper.append(li.firstChild);
+      li.appendChild(wrapper);
+    }
+    ul.append(li);
+  });
+  ul.querySelectorAll('picture > img').forEach((img) => {
+    const optimizedPic = createOptimizedPicture(img.src, img.alt, false, [{ width: '750' }]);
+    moveInstrumentation(img, optimizedPic.querySelector('img'));
+    img.closest('picture').replaceWith(optimizedPic);
+  });
+  block.textContent = '';
+  block.append(ul);
+}

--- a/component-definition.json
+++ b/component-definition.json
@@ -98,6 +98,21 @@
           }
         },
         {
+          "title": "Moto Cards",
+          "id": "motocards",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block",
+                "template": {
+                  "name": "Moto Cards",
+                  "filter": "motocards"
+                }
+              }
+            }
+          }
+        },
+        {
           "title": "Card",
           "id": "card",
           "plugins": {

--- a/component-filters.json
+++ b/component-filters.json
@@ -14,6 +14,7 @@
       "title",
       "hero",
       "cards",
+      "motocards",
       "columns",
       "fragment",
       "tabs",
@@ -23,6 +24,12 @@
   },
   {
     "id": "cards",
+    "components": [
+      "card"
+    ]
+  },
+  {
+    "id": "motocards",
     "components": [
       "card"
     ]


### PR DESCRIPTION
## Summary
- add `motocards` block implementing image cards with overlay text
- register Moto Cards block in component definition and filters

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68429088518c8322bd595d3d30f5496b