### PR TITLE
Add simple fuel ordering mobile app

### DIFF
--- a/mobile-app/app.css
+++ b/mobile-app/app.css
@@ -1,0 +1,13 @@
+/* minimal styling for fuel app */
+main {
+    text-align: center;
+}
+form p {
+    margin: 1em 0;
+}
+input[type="text"],
+input[type="datetime-local"] {
+    padding: 0.5em;
+    width: 100%;
+    max-width: 300px;
+}

--- a/mobile-app/app.js
+++ b/mobile-app/app.js
@@ -1,0 +1,39 @@
+function getLocation() {
+  return new Promise((resolve, reject) => {
+    if (!navigator.geolocation) {
+      reject(new Error('Geolocation not supported'));
+    } else {
+      navigator.geolocation.getCurrentPosition(
+        (pos) => resolve(`${pos.coords.latitude},${pos.coords.longitude}`),
+        reject,
+      );
+    }
+  });
+}
+
+async function handleOrderNow(e) {
+  e.preventDefault();
+  const status = document.getElementById('status');
+  status.textContent = 'Placing order…';
+  try {
+    const location = await getLocation();
+    status.textContent = `Fuel will be delivered to: ${location}`;
+  } catch (err) {
+    status.textContent = `Unable to get location: ${err.message}`;
+  }
+}
+
+async function handleSchedule(e) {
+  e.preventDefault();
+  const time = document.getElementById('delivery-time').value;
+  const address = document.getElementById('address').value;
+  const status = document.getElementById('schedule-status');
+  status.textContent = `Scheduled for ${time} at ${address}`;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const nowForm = document.getElementById('now-form');
+  if (nowForm) nowForm.addEventListener('submit', handleOrderNow);
+  const scheduleForm = document.getElementById('schedule-form');
+  if (scheduleForm) scheduleForm.addEventListener('submit', handleSchedule);
+});

--- a/mobile-app/index.html
+++ b/mobile-app/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Fuel Ordering App</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="../styles/styles.css">
+  <link rel="stylesheet" href="app.css">
+  <script type="module" src="../scripts/scripts.js"></script>
+</head>
+<body>
+  <header></header>
+  <main>
+    <div class="section">
+      <h1>Fuel Delivery</h1>
+      <p>Select an option below to continue.</p>
+      <p class="button-container">
+        <a class="button" href="order-now.html">Order Fuel Now</a>
+        <a class="button secondary" href="schedule-order.html">Schedule Delivery</a>
+      </p>
+    </div>
+  </main>
+  <footer></footer>
+</body>
+</html>

--- a/mobile-app/order-now.html
+++ b/mobile-app/order-now.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Order Fuel Now</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="../styles/styles.css">
+  <link rel="stylesheet" href="app.css">
+  <script type="module" src="../scripts/scripts.js"></script>
+  <script type="module" src="app.js"></script>
+</head>
+<body>
+  <header></header>
+  <main>
+    <div class="section">
+      <h1>Order Fuel Now</h1>
+      <p>Your current location will be used for delivery.</p>
+      <form id="now-form">
+        <p><button type="submit" class="button">Place Order</button></p>
+      </form>
+      <p id="status"></p>
+    </div>
+  </main>
+  <footer></footer>
+</body>
+</html>

--- a/mobile-app/schedule-order.html
+++ b/mobile-app/schedule-order.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Schedule Fuel Delivery</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="../styles/styles.css">
+  <link rel="stylesheet" href="app.css">
+  <script type="module" src="../scripts/scripts.js"></script>
+  <script type="module" src="app.js"></script>
+</head>
+<body>
+  <header></header>
+  <main>
+    <div class="section">
+      <h1>Schedule Fuel Delivery</h1>
+      <form id="schedule-form">
+        <p>
+          <label>Delivery Date and Time<br>
+            <input type="datetime-local" id="delivery-time" required>
+          </label>
+        </p>
+        <p>
+          <label>Address<br>
+            <input type="text" id="address" required>
+          </label>
+        </p>
+        <p><button type="submit" class="button">Schedule</button></p>
+      </form>
+      <p id="schedule-status"></p>
+    </div>
+  </main>
+  <footer></footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `mobile-app` with fuel ordering interface
- create home page with quick links to order now or schedule delivery
- implement order now page that uses geolocation
- implement schedule order page with basic form
- include lightweight CSS and JS for functionality

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6842c6c48cd88322a6c219d22a983a09