### PR TITLE
Add Moto Cards block

### DIFF
--- a/blocks/motocards/_motocards.json
+++ b/blocks/motocards/_motocards.json
@@ -1,0 +1,73 @@
+{
+  "definitions": [
+    {
+      "title": "MotoCards",
+      "id": "motocards",
+      "plugins": {
+        "xwalk": {
+          "page": {
+            "resourceType": "core/franklin/components/block/v1/block",
+            "template": {
+              "name": "MotoCards",
+              "filter": "motocards"
+            }
+          }
+        }
+      }
+    },
+    {
+      "title": "Moto Card",
+      "id": "moto-card",
+      "plugins": {
+        "xwalk": {
+          "page": {
+            "resourceType": "core/franklin/components/block/v1/block/item",
+            "template": {
+              "name": "Moto Card",
+              "model": "moto-card"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "models": [
+    {
+      "id": "moto-card",
+      "fields": [
+        {
+          "component": "reference",
+          "valueType": "string",
+          "name": "image",
+          "label": "Image",
+          "multi": false
+        },
+        {
+          "component": "richtext",
+          "name": "text",
+          "value": "",
+          "label": "Text",
+          "valueType": "string"
+        },
+        {
+          "component": "aem-content",
+          "name": "primaryLink",
+          "label": "Primary Link"
+        },
+        {
+          "component": "aem-content",
+          "name": "secondaryLink",
+          "label": "Secondary Link"
+        }
+      ]
+    }
+  ],
+  "filters": [
+    {
+      "id": "motocards",
+      "components": [
+        "moto-card"
+      ]
+    }
+  ]
+}

--- a/blocks/motocards/motocards.css
+++ b/blocks/motocards/motocards.css
@@ -1,0 +1,12 @@
+
+@import url('https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css');
+
+main > .section > div.motocards-wrapper {
+  max-width: none;
+  padding: 0;
+}
+
+/* transition helper for CTA row */
+.motocards .cta-row {
+  transition: opacity 0.3s, transform 0.3s;
+}

--- a/blocks/motocards/motocards.js
+++ b/blocks/motocards/motocards.js
@@ -1,0 +1,58 @@
+import { createOptimizedPicture } from '../../scripts/aem.js';
+import { moveInstrumentation } from '../../scripts/scripts.js';
+
+export default function decorate(block) {
+  const ul = document.createElement('ul');
+  ul.classList.add('grid', 'grid-cols-1', 'md:grid-cols-2', 'lg:grid-cols-3', 'gap-6');
+
+  [...block.children].forEach((row) => {
+    const li = document.createElement('li');
+    li.classList.add('relative', 'overflow-hidden', 'rounded', 'group', 'text-white');
+    moveInstrumentation(row, li);
+
+    const [imgDiv, textDiv, primaryDiv, secondaryDiv] = [...row.children];
+
+    if (imgDiv) {
+      imgDiv.className = 'motocards-card-image';
+      li.append(imgDiv);
+    }
+
+    const ctaRow = document.createElement('div');
+    ctaRow.className = 'cta-row absolute inset-0 flex items-center justify-center gap-4 opacity-0 translate-y-2 group-hover:opacity-100 group-hover:translate-y-0';
+
+    [primaryDiv, secondaryDiv].forEach((div, idx) => {
+      const link = div?.querySelector('a');
+      if (link) {
+        link.classList.add('cta', 'px-4', 'py-2', 'text-sm', 'font-medium', 'rounded');
+        if (idx === 0) {
+          link.classList.add('bg-red-600', 'text-white');
+        } else {
+          link.classList.add('border', 'border-white', 'text-white');
+        }
+        ctaRow.append(link);
+      }
+    });
+
+    if (ctaRow.children.length) li.append(ctaRow);
+
+    if (textDiv) {
+      const overlay = document.createElement('div');
+      overlay.className = 'absolute bottom-0 left-0 w-full bg-black bg-opacity-70 p-4';
+      overlay.innerHTML = textDiv.innerHTML;
+      overlay.querySelectorAll('p').forEach((p) => p.classList.add('font-bold', 'm-0'));
+      li.append(overlay);
+    }
+
+    ul.append(li);
+  });
+
+  ul.querySelectorAll('picture > img').forEach((img) => {
+    const optimizedPic = createOptimizedPicture(img.src, img.alt, false, [{ width: '750' }]);
+    moveInstrumentation(img, optimizedPic.querySelector('img'));
+    img.closest('picture').replaceWith(optimizedPic);
+  });
+
+  block.textContent = '';
+  block.classList.add('bg-black', 'py-8');
+  block.append(ul);
+}

--- a/blocks/supportcards/_supportcards.json
+++ b/blocks/supportcards/_supportcards.json
@@ -1,0 +1,68 @@
+{
+  "definitions": [
+    {
+      "title": "SupportCards",
+      "id": "supportcards",
+      "plugins": {
+        "xwalk": {
+          "page": {
+            "resourceType": "core/franklin/components/block/v1/block",
+            "template": {
+              "name": "SupportCards",
+              "filter": "supportcards"
+            }
+          }
+        }
+      }
+    },
+    {
+      "title": "Support Card",
+      "id": "support-card",
+      "plugins": {
+        "xwalk": {
+          "page": {
+            "resourceType": "core/franklin/components/block/v1/block/item",
+            "template": {
+              "name": "Support Card",
+              "model": "support-card"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "models": [
+    {
+      "id": "support-card",
+      "fields": [
+        {
+          "component": "reference",
+          "valueType": "string",
+          "name": "image",
+          "label": "Image",
+          "multi": false
+        },
+        {
+          "component": "richtext",
+          "name": "text",
+          "value": "",
+          "label": "Text",
+          "valueType": "string"
+        },
+        {
+          "component": "aem-content",
+          "name": "link",
+          "label": "Link"
+        }
+      ]
+    }
+  ],
+  "filters": [
+    {
+      "id": "supportcards",
+      "components": [
+        "support-card"
+      ]
+    }
+  ]
+}

--- a/blocks/supportcards/supportcards.css
+++ b/blocks/supportcards/supportcards.css
@@ -1,0 +1,10 @@
+@import url('https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css');
+
+main > .section > div.supportcards-wrapper {
+  max-width: none;
+  padding: 0;
+}
+
+.supportcards .cta-row {
+  transition: opacity 0.3s, transform 0.3s;
+}

--- a/blocks/supportcards/supportcards.js
+++ b/blocks/supportcards/supportcards.js
@@ -1,0 +1,51 @@
+import { createOptimizedPicture } from '../../scripts/aem.js';
+import { moveInstrumentation } from '../../scripts/scripts.js';
+
+export default function decorate(block) {
+  const ul = document.createElement('ul');
+  ul.classList.add('grid', 'grid-cols-1', 'md:grid-cols-2', 'lg:grid-cols-3', 'gap-6');
+
+  [...block.children].forEach((row) => {
+    const li = document.createElement('li');
+    li.classList.add('relative', 'overflow-hidden', 'rounded', 'group', 'text-white');
+    moveInstrumentation(row, li);
+
+    const [imgDiv, textDiv, linkDiv] = [...row.children];
+
+    if (imgDiv) {
+      imgDiv.className = 'supportcards-card-image';
+      li.append(imgDiv);
+    }
+
+    const ctaRow = document.createElement('div');
+    ctaRow.className = 'cta-row absolute inset-0 flex items-center justify-center opacity-0 translate-y-2 group-hover:opacity-100 group-hover:translate-y-0';
+
+    const link = linkDiv?.querySelector('a');
+    if (link) {
+      link.classList.add('px-4', 'py-2', 'text-sm', 'font-medium', 'rounded', 'bg-red-600', 'text-white');
+      ctaRow.append(link);
+    }
+
+    if (ctaRow.children.length) li.append(ctaRow);
+
+    if (textDiv) {
+      const overlay = document.createElement('div');
+      overlay.className = 'absolute bottom-0 left-0 w-full bg-black bg-opacity-70 p-4';
+      overlay.innerHTML = textDiv.innerHTML;
+      overlay.querySelectorAll('p').forEach((p) => p.classList.add('font-bold', 'm-0'));
+      li.append(overlay);
+    }
+
+    ul.append(li);
+  });
+
+  ul.querySelectorAll('picture > img').forEach((img) => {
+    const optimizedPic = createOptimizedPicture(img.src, img.alt, false, [{ width: '750' }]);
+    moveInstrumentation(img, optimizedPic.querySelector('img'));
+    img.closest('picture').replaceWith(optimizedPic);
+  });
+
+  block.textContent = '';
+  block.classList.add('bg-black', 'py-8');
+  block.append(ul);
+}

--- a/blocks/supportcontact/_supportcontact.json
+++ b/blocks/supportcontact/_supportcontact.json
@@ -1,0 +1,39 @@
+{
+  "definitions": [
+    {
+      "title": "Support Contact",
+      "id": "supportcontact",
+      "plugins": {
+        "xwalk": {
+          "page": {
+            "resourceType": "core/franklin/components/block/v1/block",
+            "template": {
+              "name": "Support Contact",
+              "model": "supportcontact"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "models": [
+    {
+      "id": "supportcontact",
+      "fields": [
+        {
+          "component": "richtext",
+          "name": "text",
+          "value": "",
+          "label": "Text",
+          "valueType": "string"
+        },
+        {
+          "component": "aem-content",
+          "name": "link",
+          "label": "Link"
+        }
+      ]
+    }
+  ],
+  "filters": []
+}

--- a/blocks/supportcontact/supportcontact.css
+++ b/blocks/supportcontact/supportcontact.css
@@ -1,0 +1,10 @@
+.supportcontact {
+  text-align: center;
+  padding: 40px 24px;
+  background: #111;
+  color: #fff;
+}
+
+.supportcontact .button-container {
+  margin-top: 16px;
+}

--- a/blocks/supportcontact/supportcontact.js
+++ b/blocks/supportcontact/supportcontact.js
@@ -1,0 +1,5 @@
+import { decorateButtons } from '../../scripts/aem.js';
+
+export default function decorate(block) {
+  decorateButtons(block);
+}

--- a/blocks/supporthero/_supporthero.json
+++ b/blocks/supporthero/_supporthero.json
@@ -1,0 +1,48 @@
+{
+  "definitions": [
+    {
+      "title": "Support Hero",
+      "id": "supporthero",
+      "plugins": {
+        "xwalk": {
+          "page": {
+            "resourceType": "core/franklin/components/block/v1/block",
+            "template": {
+              "name": "Support Hero",
+              "model": "supporthero"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "models": [
+    {
+      "id": "supporthero",
+      "fields": [
+        {
+          "component": "reference",
+          "valueType": "string",
+          "name": "image",
+          "label": "Image",
+          "multi": false
+        },
+        {
+          "component": "text",
+          "valueType": "string",
+          "name": "imageAlt",
+          "label": "Alt",
+          "value": ""
+        },
+        {
+          "component": "richtext",
+          "name": "text",
+          "label": "Text",
+          "valueType": "string",
+          "value": ""
+        }
+      ]
+    }
+  ],
+  "filters": []
+}

--- a/blocks/supporthero/supporthero.css
+++ b/blocks/supporthero/supporthero.css
@@ -1,0 +1,36 @@
+.supporthero-container .supporthero-wrapper {
+  max-width: unset;
+  padding: 0;
+}
+
+.supporthero {
+  position: relative;
+  padding: 40px 24px;
+  min-height: 300px;
+}
+
+.supporthero h1 {
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
+  color: var(--background-color);
+}
+
+.supporthero picture {
+  position: absolute;
+  z-index: -1;
+  inset: 0;
+  box-sizing: border-box;
+}
+
+.supporthero img {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+}
+
+@media (width >= 900px) {
+  .supporthero {
+    padding: 40px 32px;
+  }
+}

--- a/blocks/supporthero/supporthero.js
+++ b/blocks/supporthero/supporthero.js
@@ -1,0 +1,3 @@
+export default function decorate() {
+  /* No JS needed for static hero */
+}

--- a/component-definition.json
+++ b/component-definition.json
@@ -98,6 +98,21 @@
           }
         },
         {
+          "title": "MotoCards",
+          "id": "motocards",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block",
+                "template": {
+                  "name": "MotoCards",
+                  "filter": "motocards"
+                }
+              }
+            }
+          }
+        },
+        {
           "title": "Card",
           "id": "card",
           "plugins": {
@@ -107,6 +122,81 @@
                 "template": {
                   "name": "Card",
                   "model": "card"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Moto Card",
+          "id": "moto-card",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block/item",
+                "template": {
+                  "name": "Moto Card",
+                  "model": "moto-card"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "SupportCards",
+          "id": "supportcards",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block",
+                "template": {
+                  "name": "SupportCards",
+                  "filter": "supportcards"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Support Card",
+          "id": "support-card",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block/item",
+                "template": {
+                  "name": "Support Card",
+                  "model": "support-card"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Support Hero",
+          "id": "supporthero",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block",
+                "template": {
+                  "name": "Support Hero",
+                  "model": "supporthero"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Support Contact",
+          "id": "supportcontact",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block",
+                "template": {
+                  "name": "Support Contact",
+                  "model": "supportcontact"
                 }
               }
             }

--- a/component-filters.json
+++ b/component-filters.json
@@ -14,6 +14,10 @@
       "title",
       "hero",
       "cards",
+      "motocards",
+      "supporthero",
+      "supportcards",
+      "supportcontact",
       "columns",
       "fragment",
       "tabs",
@@ -25,6 +29,18 @@
     "id": "cards",
     "components": [
       "card"
+    ]
+  },
+  {
+    "id": "motocards",
+    "components": [
+      "moto-card"
+    ]
+  },
+  {
+    "id": "supportcards",
+    "components": [
+      "support-card"
     ]
   },
   {

--- a/component-models.json
+++ b/component-models.json
@@ -8,7 +8,7 @@
         "name": "jcr:title",
         "label": "Title"
       },
-      {
+  {
         "component": "text",
         "valueType": "string",
         "name": "jcr:description",
@@ -395,6 +395,103 @@
             "value": "right"
           }
         ]
+      }
+    ]
+  },
+  {
+    "id": "moto-card",
+    "fields": [
+      {
+        "component": "reference",
+        "valueType": "string",
+        "name": "image",
+        "label": "Image",
+        "multi": false
+      },
+      {
+        "component": "richtext",
+        "name": "text",
+        "value": "",
+        "label": "Text",
+        "valueType": "string"
+      },
+      {
+        "component": "aem-content",
+        "name": "primaryLink",
+        "label": "Primary Link"
+      },
+      {
+        "component": "aem-content",
+        "name": "secondaryLink",
+        "label": "Secondary Link"
+      }
+    ]
+  }
+  ,
+  {
+    "id": "support-card",
+    "fields": [
+      {
+        "component": "reference",
+        "valueType": "string",
+        "name": "image",
+        "label": "Image",
+        "multi": false
+      },
+      {
+        "component": "richtext",
+        "name": "text",
+        "value": "",
+        "label": "Text",
+        "valueType": "string"
+      },
+      {
+        "component": "aem-content",
+        "name": "link",
+        "label": "Link"
+      }
+    ]
+  },
+  {
+    "id": "supporthero",
+    "fields": [
+      {
+        "component": "reference",
+        "valueType": "string",
+        "name": "image",
+        "label": "Image",
+        "multi": false
+      },
+      {
+        "component": "text",
+        "valueType": "string",
+        "name": "imageAlt",
+        "label": "Alt",
+        "value": ""
+      },
+      {
+        "component": "richtext",
+        "name": "text",
+        "label": "Text",
+        "valueType": "string",
+        "value": ""
+      }
+    ]
+  },
+  {
+    "id": "supportcontact",
+    "fields": [
+      {
+        "component": "richtext",
+        "name": "text",
+        "value": "",
+        "label": "Text",
+        "valueType": "string"
+      },
+      {
+        "component": "aem-content",
+        "name": "link",
+        "label": "Link"
       }
     ]
   }


### PR DESCRIPTION
## Summary
- add `moto-cards` block implementing image cards with dual CTAs
- register Moto Cards model and filters
- update generated component definitions and models
- rename Moto Cards to MotoCards in configuration
- rename `moto-cards` to `motocards` everywhere
- update motocards to use a Tailwind-based responsive grid
- add support blocks for Support page sections

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js file)*
- `npm run build:json` *(fails: npm-run-all not found)*

------
https://chatgpt.com/codex/tasks/task_e_68429088518c8322bd595d3d30f5496b