### PR TITLE
Add Accordion and Contact blocks

### DIFF
--- a/blocks/accordion/_accordion.json
+++ b/blocks/accordion/_accordion.json
@@ -1,0 +1,61 @@
+{
+  "definitions": [
+    {
+      "title": "Accordion",
+      "id": "accordion",
+      "plugins": {
+        "xwalk": {
+          "page": {
+            "resourceType": "core/franklin/components/block/v1/block",
+            "template": {
+              "name": "Accordion",
+              "filter": "accordion"
+            }
+          }
+        }
+      }
+    },
+    {
+      "title": "Accordion Item",
+      "id": "accordion-item",
+      "plugins": {
+        "xwalk": {
+          "page": {
+            "resourceType": "core/franklin/components/block/v1/block/item",
+            "template": {
+              "name": "Accordion Item",
+              "model": "accordion-item"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "models": [
+    {
+      "id": "accordion-item",
+      "fields": [
+        {
+          "component": "text",
+          "name": "title",
+          "label": "Title",
+          "valueType": "string"
+        },
+        {
+          "component": "richtext",
+          "name": "text",
+          "label": "Text",
+          "valueType": "string"
+        }
+      ]
+    }
+  ],
+  "filters": [
+    {
+      "id": "accordion",
+      "components": [
+        "accordion-item"
+      ]
+    }
+  ]
+}

--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -1,0 +1,37 @@
+main > .section > div.accordion-wrapper {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0;
+}
+
+.accordion {
+  border-top: 1px solid #ccc;
+}
+
+.accordion-item {
+  border-bottom: 1px solid #ccc;
+}
+
+.accordion-title {
+  width: 100%;
+  background: none;
+  border: none;
+  text-align: left;
+  font-size: 1.2em;
+  padding: 16px;
+  cursor: pointer;
+}
+
+.accordion-title::after {
+  content: '\25BC';
+  float: right;
+  transition: transform 0.3s;
+}
+
+.accordion-title[aria-expanded='true']::after {
+  transform: rotate(-180deg);
+}
+
+.accordion-panel {
+  padding: 0 16px 16px;
+}

--- a/blocks/accordion/accordion.js
+++ b/blocks/accordion/accordion.js
@@ -1,0 +1,26 @@
+export default function decorate(block) {
+  [...block.children].forEach((row) => {
+    const item = document.createElement('div');
+    item.className = 'accordion-item';
+    const [titleDiv, contentDiv] = [...row.children];
+    const button = document.createElement('button');
+    button.className = 'accordion-title';
+    button.innerHTML = titleDiv ? titleDiv.innerHTML : '';
+    button.setAttribute('aria-expanded', 'false');
+
+    const panel = document.createElement('div');
+    panel.className = 'accordion-panel';
+    panel.innerHTML = contentDiv ? contentDiv.innerHTML : '';
+    panel.hidden = true;
+
+    button.addEventListener('click', () => {
+      const expanded = button.getAttribute('aria-expanded') === 'true';
+      button.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+      panel.hidden = expanded;
+    });
+
+    item.append(button, panel);
+    row.replaceWith(item);
+  });
+  block.classList.add('accordion');
+}

--- a/blocks/contact/_contact.json
+++ b/blocks/contact/_contact.json
@@ -1,0 +1,61 @@
+{
+  "definitions": [
+    {
+      "title": "Contact",
+      "id": "contact",
+      "plugins": {
+        "xwalk": {
+          "page": {
+            "resourceType": "core/franklin/components/block/v1/block",
+            "template": {
+              "name": "Contact",
+              "filter": "contact"
+            }
+          }
+        }
+      }
+    },
+    {
+      "title": "Contact Item",
+      "id": "contact-item",
+      "plugins": {
+        "xwalk": {
+          "page": {
+            "resourceType": "core/franklin/components/block/v1/block/item",
+            "template": {
+              "name": "Contact Item",
+              "model": "contact-item"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "models": [
+    {
+      "id": "contact-item",
+      "fields": [
+        {
+          "component": "text",
+          "name": "title",
+          "label": "Title",
+          "valueType": "string"
+        },
+        {
+          "component": "richtext",
+          "name": "text",
+          "label": "Text",
+          "valueType": "string"
+        }
+      ]
+    }
+  ],
+  "filters": [
+    {
+      "id": "contact",
+      "components": [
+        "contact-item"
+      ]
+    }
+  ]
+}

--- a/blocks/contact/contact.css
+++ b/blocks/contact/contact.css
@@ -1,0 +1,19 @@
+main > .section > div.contact-wrapper {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0;
+}
+
+.contact-item {
+  padding: 16px 0;
+  border-bottom: 1px solid #ccc;
+}
+
+.contact-item:last-child {
+  border-bottom: none;
+}
+
+.contact-title {
+  font-weight: 600;
+  margin-bottom: 4px;
+}

--- a/blocks/contact/contact.js
+++ b/blocks/contact/contact.js
@@ -1,0 +1,20 @@
+export default function decorate(block) {
+  [...block.children].forEach((row) => {
+    const item = document.createElement('div');
+    item.className = 'contact-item';
+    const [titleDiv, textDiv] = [...row.children];
+    if (titleDiv) {
+      const title = document.createElement('div');
+      title.className = 'contact-title';
+      title.innerHTML = titleDiv.innerHTML;
+      item.append(title);
+    }
+    if (textDiv) {
+      const text = document.createElement('div');
+      text.className = 'contact-text';
+      text.innerHTML = textDiv.innerHTML;
+      item.append(text);
+    }
+    row.replaceWith(item);
+  });
+}

--- a/component-definition.json
+++ b/component-definition.json
@@ -217,6 +217,66 @@
               }
             }
           }
+        },
+        {
+          "title": "Accordion",
+          "id": "accordion",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block",
+                "template": {
+                  "name": "Accordion",
+                  "filter": "accordion"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Accordion Item",
+          "id": "accordion-item",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block/item",
+                "template": {
+                  "name": "Accordion Item",
+                  "model": "accordion-item"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Contact",
+          "id": "contact",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block",
+                "template": {
+                  "name": "Contact",
+                  "filter": "contact"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Contact Item",
+          "id": "contact-item",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block/item",
+                "template": {
+                  "name": "Contact Item",
+                  "model": "contact-item"
+                }
+              }
+            }
+          }
         }
       ]
     },
@@ -241,13 +301,13 @@
         },
         {
           "title": "Carousel",
-          "id":   "carousel",
+          "id": "carousel",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/franklin/components/block/v1/block",
                 "template": {
-                  "name":   "Carousel",
+                  "name": "Carousel",
                   "filter": "carousel"
                 }
               }
@@ -256,13 +316,13 @@
         },
         {
           "title": "Slide",
-          "id":   "slide",
+          "id": "slide",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/franklin/components/block/v1/block/item",
                 "template": {
-                  "name":  "Slide",
+                  "name": "Slide",
                   "model": "slide"
                 }
               }

--- a/component-filters.json
+++ b/component-filters.json
@@ -19,7 +19,9 @@
       "fragment",
       "tabs",
       "carousel",
-      "imagetext"
+      "imagetext",
+      "accordion",
+      "contact"
     ]
   },
   {
@@ -61,6 +63,18 @@
       "imagetext",
       "tab",
       "title"
+    ]
+  },
+  {
+    "id": "accordion",
+    "components": [
+      "accordion-item"
+    ]
+  },
+  {
+    "id": "contact",
+    "components": [
+      "contact-item"
     ]
   }
 ]

--- a/component-models.json
+++ b/component-models.json
@@ -8,7 +8,7 @@
         "name": "jcr:title",
         "label": "Title"
       },
-  {
+      {
         "component": "text",
         "valueType": "string",
         "name": "jcr:description",
@@ -424,6 +424,40 @@
         "component": "aem-content",
         "name": "secondaryLink",
         "label": "Secondary Link"
+      }
+    ]
+  },
+  {
+    "id": "accordion-item",
+    "fields": [
+      {
+        "component": "text",
+        "name": "title",
+        "label": "Title",
+        "valueType": "string"
+      },
+      {
+        "component": "richtext",
+        "name": "text",
+        "label": "Text",
+        "valueType": "string"
+      }
+    ]
+  },
+  {
+    "id": "contact-item",
+    "fields": [
+      {
+        "component": "text",
+        "name": "title",
+        "label": "Title",
+        "valueType": "string"
+      },
+      {
+        "component": "richtext",
+        "name": "text",
+        "label": "Text",
+        "valueType": "string"
       }
     ]
   }


### PR DESCRIPTION
## Summary
- create Accordion and Contact blocks to support Support page sections
- generate metadata entries for new blocks

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684312f3243c832294decd181921b932