### PR TITLE
Add SupportCards block

### DIFF
--- a/blocks/supportcards/_supportcards.json
+++ b/blocks/supportcards/_supportcards.json
@@ -1,0 +1,95 @@
+{
+  "definitions": [
+    {
+      "title": "SupportCards",
+      "id": "supportcards",
+      "plugins": {
+        "xwalk": {
+          "page": {
+            "resourceType": "core/franklin/components/block/v1/block",
+            "template": {
+              "name": "SupportCards",
+              "filter": "supportcards"
+            }
+          }
+        }
+      }
+    },
+    {
+      "title": "SupportCard",
+      "id": "supportcard",
+      "plugins": {
+        "xwalk": {
+          "page": {
+            "resourceType": "core/franklin/components/block/v1/block/item",
+            "template": {
+              "name": "SupportCard",
+              "model": "supportcard"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "models": [
+    {
+      "id": "supportcard",
+      "fields": [
+        {
+          "component": "reference",
+          "valueType": "string",
+          "name": "image",
+          "label": "Image",
+          "multi": false
+        },
+        {
+          "component": "text",
+          "valueType": "string",
+          "name": "imageAlt",
+          "label": "Alt",
+          "value": ""
+        },
+        {
+          "component": "reference",
+          "valueType": "string",
+          "name": "icon",
+          "label": "Icon",
+          "multi": false
+        },
+        {
+          "component": "text",
+          "valueType": "string",
+          "name": "iconAlt",
+          "label": "Icon Alt",
+          "value": ""
+        },
+        {
+          "component": "richtext",
+          "name": "text",
+          "value": "",
+          "label": "Text",
+          "valueType": "string"
+        },
+        {
+          "component": "text",
+          "name": "linkLabel",
+          "label": "Link Label",
+          "valueType": "string"
+        },
+        {
+          "component": "aem-content",
+          "name": "link",
+          "label": "Link"
+        }
+      ]
+    }
+  ],
+  "filters": [
+    {
+      "id": "supportcards",
+      "components": [
+        "supportcard"
+      ]
+    }
+  ]
+}

--- a/blocks/supportcards/supportcards.css
+++ b/blocks/supportcards/supportcards.css
@@ -1,0 +1,72 @@
+main > .section > div.supportcards-wrapper {
+  max-width: unset;
+  padding: 0;
+}
+
+.supportcards > ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(316px, 1fr));
+}
+
+.supportcards > ul > li {
+  position: relative;
+}
+
+.supportcards .card-link {
+  display: block;
+  color: inherit;
+  text-decoration: none;
+  position: relative;
+  background: #212121;
+}
+
+.supportcards .supportcards-card-image img {
+  width: 100%;
+  display: block;
+}
+
+.supportcards .supportcards-card-icon {
+  position: absolute;
+  left: 50%;
+  top: 20%;
+  width: 25%;
+  transform: translateX(-50%);
+  z-index: 1;
+}
+
+.supportcards .supportcards-card-body {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background: linear-gradient(to bottom, transparent 0, rgba(0,0,0,0.5) 100%);
+  color: #fff;
+  padding: 16px;
+  box-sizing: border-box;
+  z-index: 1;
+}
+
+.supportcards .supportcards-card-body h3 {
+  margin: 0 0 8px;
+}
+
+.supportcards .supportcards-card-body p {
+  margin: 0 0 16px;
+  font-size: 14px;
+}
+
+.supportcards .supportcards-card-link {
+  display: inline-block;
+  border: 1px solid #fff;
+  padding: 6px 12px;
+  font-size: 14px;
+}
+
+@media (max-width: 768px) {
+  .supportcards > ul {
+    grid-template-columns: 1fr;
+  }
+}

--- a/blocks/supportcards/supportcards.js
+++ b/blocks/supportcards/supportcards.js
@@ -1,0 +1,48 @@
+import { createOptimizedPicture } from '../../scripts/aem.js';
+import { moveInstrumentation } from '../../scripts/scripts.js';
+
+export default function decorate(block) {
+  const ul = document.createElement('ul');
+  [...block.children].forEach((row) => {
+    const li = document.createElement('li');
+    moveInstrumentation(row, li);
+    const [imgDiv, iconDiv, textDiv, labelDiv, linkDiv] = [...row.children];
+
+    if (imgDiv) imgDiv.className = 'supportcards-card-image';
+    if (iconDiv) iconDiv.className = 'supportcards-card-icon';
+
+    const bodyDiv = document.createElement('div');
+    bodyDiv.className = 'supportcards-card-body';
+    if (textDiv) {
+      bodyDiv.append(...textDiv.childNodes);
+    }
+
+    const link = linkDiv?.querySelector('a');
+    const label = labelDiv?.textContent.trim() || link?.textContent.trim() || '';
+    if (link) {
+      const btn = document.createElement('span');
+      btn.className = 'supportcards-card-link';
+      btn.textContent = label || 'Know More';
+      bodyDiv.append(btn);
+    }
+
+    const wrapper = link ? document.createElement('a') : document.createElement('div');
+    if (link) wrapper.href = link.href;
+    wrapper.className = 'card-link';
+    if (imgDiv) wrapper.append(imgDiv);
+    if (iconDiv) wrapper.append(iconDiv);
+    wrapper.append(bodyDiv);
+
+    li.append(wrapper);
+    ul.append(li);
+  });
+
+  ul.querySelectorAll('.supportcards-card-image img').forEach((img) => {
+    const pic = createOptimizedPicture(img.src, img.alt, false, [{ width: '750' }]);
+    moveInstrumentation(img, pic.querySelector('img'));
+    img.closest('picture').replaceWith(pic);
+  });
+
+  block.textContent = '';
+  block.append(ul);
+}

--- a/component-definition.json
+++ b/component-definition.json
@@ -143,6 +143,36 @@
           }
         },
         {
+          "title": "SupportCards",
+          "id": "supportcards",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block",
+                "template": {
+                  "name": "SupportCards",
+                  "filter": "supportcards"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "SupportCard",
+          "id": "supportcard",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block/item",
+                "template": {
+                  "name": "SupportCard",
+                  "model": "supportcard"
+                }
+              }
+            }
+          }
+        },
+        {
           "title": "Columns",
           "id": "columns",
           "plugins": {

--- a/component-filters.json
+++ b/component-filters.json
@@ -15,6 +15,7 @@
       "hero",
       "cards",
       "motocards",
+      "supportcards",
       "columns",
       "fragment",
       "tabs",
@@ -32,6 +33,12 @@
     "id": "motocards",
     "components": [
       "motocard"
+    ]
+  },
+  {
+    "id": "supportcards",
+    "components": [
+      "supportcard"
     ]
   },
   {

--- a/component-models.json
+++ b/component-models.json
@@ -426,5 +426,56 @@
         "label": "Secondary Link"
       }
     ]
+  },
+  {
+    "id": "supportcard",
+    "fields": [
+      {
+        "component": "reference",
+        "valueType": "string",
+        "name": "image",
+        "label": "Image",
+        "multi": false
+      },
+      {
+        "component": "text",
+        "valueType": "string",
+        "name": "imageAlt",
+        "label": "Alt",
+        "value": ""
+      },
+      {
+        "component": "reference",
+        "valueType": "string",
+        "name": "icon",
+        "label": "Icon",
+        "multi": false
+      },
+      {
+        "component": "text",
+        "valueType": "string",
+        "name": "iconAlt",
+        "label": "Icon Alt",
+        "value": ""
+      },
+      {
+        "component": "richtext",
+        "name": "text",
+        "value": "",
+        "label": "Text",
+        "valueType": "string"
+      },
+      {
+        "component": "text",
+        "name": "linkLabel",
+        "label": "Link Label",
+        "valueType": "string"
+      },
+      {
+        "component": "aem-content",
+        "name": "link",
+        "label": "Link"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- implement new `supportcards` block with CSS and JS
- register block in component configuration files

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a78f50408322b9fb7b9ddb8d4b31